### PR TITLE
Simplifying the acodeX-server command to axs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ npm install -g acodex-server
 
 ## Usage
 
-Run `acodeX-server` to start server
+Run `axs` to start server
 
 ```
-acodeX-server
+axs
 ```
 
-and `acodeX-server --help` for help
+and `axs --help` for help
 
 > More features comming soon...
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const startServer = require("./terminalServer.js");
 const program = new Command();
 
 program
-    .name("acodeX-server")
+    .name("axs")
     .description("CLI of AcodeX Acode plugin")
     .version("1.0.7")
     .action(() => {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,10 @@
   "description": "A server of Acode AcodeX plugin",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node index.js"
   },
   "bin": {
-    "acodeX-server": "index.js"
+    "axs": "index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I think commands that are long and consist of uppercase, lowercase and special characters are quite difficult for users to type.  So I thought making it shorter would be better.

From `acodeX-server` to `axs`